### PR TITLE
Fix Korean search and add preview tooltip

### DIFF
--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -31,7 +31,11 @@ export class SearchEngine {
   ): Promise<void> {
     try {
       const raw = await vscode.workspace.fs.readFile(uri);
-      const text = new TextDecoder("utf8").decode(raw);
+      let text = new TextDecoder("utf8").decode(raw);
+
+      // 한글 등 유니코드 문자열 처리를 위해 NFC 정규화
+      text = text.normalize('NFC');
+      needle = needle.normalize('NFC');
       
       if (options.regex) {
         this.searchWithRegex(text, uri, needle, options, emit);

--- a/src/searchViewProvider.ts
+++ b/src/searchViewProvider.ts
@@ -72,8 +72,11 @@ export class SearchViewProvider implements vscode.WebviewViewProvider {
       const isCurrent = index === this._currentMatchIndex;
       const commentClass = match.isComment ? 'comment' : '';
 
+      // 미리보기용 전체 라인 추출
+      const lineText = match.fullText.split(/\r?\n/)[match.line - 1] || '';
+
       return `
-        <div class="result-item ${isCurrent ? 'current-match' : ''} ${commentClass}" data-index="${index}">
+        <div class="result-item ${isCurrent ? 'current-match' : ''} ${commentClass}" data-index="${index}" title="${this._escapeHtml(lineText)}">
           <span class="file-info">
             <span class="file-name">${fileName}</span>
             <span class="file-path">${relativePath}</span>


### PR DESCRIPTION
## Summary
- normalize search input/output for Unicode
- show entire line preview in search results as tooltip

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_688b90485cf8832fbc3b1dc820c742d0