### PR TITLE
Fix search result display

### DIFF
--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -100,12 +100,10 @@ export class SearchEngine {
         case "line":
           if (options.includeComments && this.isMatch(text, i, searchText, options)) {
             const eol = text.indexOf("\n", i);
-            const snippet = eol === -1
-              ? text.slice(i, i + 50)
-              : text.slice(i, Math.min(eol, i + 50));
             const lineStart = text.lastIndexOf("\n", i) + 1;
             const lineEnd = eol === -1 ? text.length : eol;
             const lineText = text.slice(lineStart, lineEnd);
+            const snippet = lineText.length > 200 ? lineText.slice(0, 200) : lineText;
 
             emit({
               uri,
@@ -129,13 +127,10 @@ export class SearchEngine {
           }
           if (options.includeComments && this.isMatch(text, i, searchText, options)) {
             const eol = text.indexOf("\n", i);
-            const snippet = eol === -1
-              ? text.slice(i, i + 50)
-              : text.slice(i, Math.min(eol, i + 50));
-
             const lineStart = text.lastIndexOf("\n", i) + 1;
             const lineEnd = eol === -1 ? text.length : eol;
             const lineText = text.slice(lineStart, lineEnd);
+            const snippet = lineText.length > 200 ? lineText.slice(0, 200) : lineText;
 
             emit({
               uri,
@@ -191,12 +186,10 @@ export class SearchEngine {
           // 매치 검사
           if (this.isMatch(text, i, searchText, options)) {
             const eol = text.indexOf("\n", i);
-            const snippet = eol === -1
-              ? text.slice(i, i + 50)
-              : text.slice(i, Math.min(eol, i + 50));
             const lineStart = text.lastIndexOf("\n", i) + 1;
             const lineEnd = eol === -1 ? text.length : eol;
             const lineText = text.slice(lineStart, lineEnd);
+            const snippet = lineText.length > 200 ? lineText.slice(0, 200) : lineText;
 
             emit({
               uri,
@@ -255,12 +248,10 @@ export class SearchEngine {
               const match = regex.exec(text.slice(i));
               if (match && match.index === 0) {
                 const eol = text.indexOf("\n", i);
-                const snippet = eol === -1
-                  ? text.slice(i, i + 50)
-                  : text.slice(i, Math.min(eol, i + 50));
                 const lineStart = text.lastIndexOf("\n", i) + 1;
                 const lineEnd = eol === -1 ? text.length : eol;
                 const lineText = text.slice(lineStart, lineEnd);
+                const snippet = lineText.length > 200 ? lineText.slice(0, 200) : lineText;
 
                 emit({
                   uri,
@@ -287,13 +278,10 @@ export class SearchEngine {
               const match = regex.exec(text.slice(i));
               if (match && match.index === 0) {
                 const eol = text.indexOf("\n", i);
-                const snippet = eol === -1
-                  ? text.slice(i, i + 50)
-                  : text.slice(i, Math.min(eol, i + 50));
-
                 const lineStart = text.lastIndexOf("\n", i) + 1;
                 const lineEnd = eol === -1 ? text.length : eol;
                 const lineText = text.slice(lineStart, lineEnd);
+                const snippet = lineText.length > 200 ? lineText.slice(0, 200) : lineText;
 
                 emit({
                   uri,
@@ -352,12 +340,10 @@ export class SearchEngine {
             const match = regex.exec(remainingText);
             if (match && match.index === 0) {
               const eol = text.indexOf("\n", i);
-              const snippet = eol === -1
-                ? text.slice(i, i + 50)
-                : text.slice(i, Math.min(eol, i + 50));
               const lineStart = text.lastIndexOf("\n", i) + 1;
               const lineEnd = eol === -1 ? text.length : eol;
               const lineText = text.slice(lineStart, lineEnd);
+              const snippet = lineText.length > 200 ? lineText.slice(0, 200) : lineText;
 
               emit({
                 uri,

--- a/src/searchViewProvider.ts
+++ b/src/searchViewProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { SearchMatch, SearchOptions } from "./searchEngine";
 
 export class SearchViewProvider implements vscode.WebviewViewProvider {
@@ -67,8 +68,9 @@ export class SearchViewProvider implements vscode.WebviewViewProvider {
 
   private _getHtmlForWebview(webview: vscode.Webview): string {
     const results = this._searchResults.map((match, index) => {
-      const fileName = match.uri.fsPath.split(/[\\/]/).pop() || '';
+      const fileName = path.basename(match.uri.fsPath);
       const relativePath = vscode.workspace.asRelativePath(match.uri);
+      const dirPath = path.dirname(relativePath);
       const isCurrent = index === this._currentMatchIndex;
       const commentClass = match.isComment ? 'comment' : '';
 
@@ -76,14 +78,13 @@ export class SearchViewProvider implements vscode.WebviewViewProvider {
       const lineText = match.lineText;
 
       return `
-        <div class="result-item ${isCurrent ? 'current-match' : ''} ${commentClass}" data-index="${index}" title="${this._escapeHtml(lineText)}">
+        <div class="result-item ${isCurrent ? 'current-match' : ''} ${commentClass}" data-index="${index}" title="${this._escapeHtml(lineText)}" ondblclick="goToMatch(${index})">
           <span class="file-info">
             <span class="file-name">${fileName}</span>
-            <span class="file-path">${relativePath}</span>
+            <span class="file-path">${dirPath}</span>
             <span class="line-number">${match.line}:${match.column}</span>
           </span>
           <span class="snippet">${this._escapeHtml(match.snippet)}</span>
-          <button class="go-to-btn" onclick="goToMatch(${index})">이동</button>
         </div>
       `;
     }).join('');
@@ -241,19 +242,6 @@ export class SearchViewProvider implements vscode.WebviewViewProvider {
             font-style: italic;
           }
           
-          .go-to-btn {
-            padding: 3px 6px;
-            border: 1px solid var(--vscode-button-border);
-            background: var(--vscode-button-background);
-            color: var(--vscode-button-foreground);
-            cursor: pointer;
-            border-radius: 2px;
-            font-size: 10px;
-          }
-          
-          .go-to-btn:hover {
-            background: var(--vscode-button-hoverBackground);
-          }
           
           .no-results {
             text-align: center;


### PR DESCRIPTION
## Summary
- adjust snippet generation to start from the beginning of each line
- show only filename and directory path
- open a result on double-click instead of using a button

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_688be96f0318832fab07f86b9c1f9d28