### PR TITLE
Implement navigation starting from double-click selection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { SearchEngine, SearchMatch } from "./searchEngine";
 import { SearchViewProvider } from "./searchViewProvider";
 
-class AdvancedSearchProvider {
+export class AdvancedSearchProvider {
   private static instance: AdvancedSearchProvider;
   private searchResults: SearchMatch[] = [];
   private currentMatchIndex: number = -1;
@@ -117,11 +117,16 @@ class AdvancedSearchProvider {
 
   prevMatch() {
     if (this.searchResults.length === 0) return;
-    
-    this.currentMatchIndex = this.currentMatchIndex <= 0 
-      ? this.searchResults.length - 1 
+
+    this.currentMatchIndex = this.currentMatchIndex <= 0
+      ? this.searchResults.length - 1
       : this.currentMatchIndex - 1;
     this.goToMatch(this.currentMatchIndex);
+  }
+
+  setCurrentMatchIndex(index: number) {
+    if (index < 0 || index >= this.searchResults.length) return;
+    this.currentMatchIndex = index;
   }
 
   async goToMatch(index: number) {
@@ -139,9 +144,9 @@ class AdvancedSearchProvider {
       
       editor.selection = new vscode.Selection(position, position.translate(0, match.matchLength));
       editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
-      
-      // 사이드바 뷰 업데이트
-      this.viewProvider.updateSearchResults(this.searchResults, this.searchQuery, this.searchOptions);
+
+      // 현재 매치 하이라이트
+      this.viewProvider.highlightMatch(index);
     } catch (error) {
       vscode.window.showErrorMessage(`파일을 열 수 없습니다: ${match.uri.fsPath}`);
     }

--- a/src/searchViewProvider.ts
+++ b/src/searchViewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { SearchMatch, SearchOptions } from "./searchEngine";
+import { AdvancedSearchProvider } from "./extension";
 
 export class SearchViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "advSearch.searchResults";
@@ -355,6 +356,7 @@ export class SearchViewProvider implements vscode.WebviewViewProvider {
 
     const match = this._searchResults[index];
     this._currentMatchIndex = index;
+    AdvancedSearchProvider.getInstance().setCurrentMatchIndex(index);
 
     try {
       const document = await vscode.workspace.openTextDocument(match.uri);
@@ -400,4 +402,10 @@ export class SearchViewProvider implements vscode.WebviewViewProvider {
       this._view.webview.html = this._getHtmlForWebview(this._view.webview);
     }
   }
-} 
+
+  public highlightMatch(index: number): void {
+    if (index < 0 || index >= this._searchResults.length) return;
+    this._currentMatchIndex = index;
+    this._updateView();
+  }
+}


### PR DESCRIPTION
## Summary
- export `AdvancedSearchProvider`
- keep navigation index synchronized when selecting a result via double-click
- highlight the active result without resetting the list

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_688c3c944e88832f948b16530a98a5e3